### PR TITLE
implemented add_listener function

### DIFF
--- a/lib/chartkick.ex
+++ b/lib/chartkick.ex
@@ -45,6 +45,22 @@ defmodule Chartkick do
     """
   end
 
+  def add_listener(id, action, func) do
+    """
+    <script type="text/javascript">
+    addChartkickListener = function(id, action, func){
+      var chartWrapper = Chartkick.charts[id];
+      if (!chartWrapper.chart){
+        setTimeout(function(){addChartkickListener(id, action, func)}, 500);
+      } else {
+        google.visualization.events.addListener(chartWrapper.chart, action, func);
+      }
+    }
+    addChartkickListener('#{id}', '#{action}', #{func});
+    </script>
+    """
+  end
+
   def chartkick_script(klass, id, data_source, options_json) do
     "<script type=\"text/javascript\">new Chartkick.#{klass}('#{id}', #{data_source}, #{options_json});</script>"
   end


### PR DESCRIPTION
Added a function that allows access to the `google.visualization.events.addListener` function. Usage example below:
Inline function example:
```elixir
<%=
data
|> Poison.encode!
|> Chartkick.column_chart(id: "alerts")
|> raw %>

<% click_function = """
function(e) {
  var chartWrapper = Chartkick.charts["alerts"];
  var selection = chartWrapper.chart.getSelection()[0];
  console.log(selection);
}
""" %>

<%= Chartkick.add_listener("alerts", "select", click_function) |> raw %>
```
Named Function version:
```elixir
<script language="javascript">
logSelection = function() {
  var chartWrapper = Chartkick.charts["alerts"];
  var selection = chartWrapper.chart.getSelection()[0];
  console.log(selection);
}
</script>
<%=
data
|> Poison.encode!
|> Chartkick.column_chart(id: "alerts")
|> raw %>

<%= Chartkick.add_listener("alerts", "select", "logSelection") |> raw %>
```