### PR TITLE
Convert options to json just before putting it in the template.

### DIFF
--- a/lib/chartkick.ex
+++ b/lib/chartkick.ex
@@ -1,6 +1,5 @@
 defmodule Chartkick do
   require EEx
-  @json_serializer Poison
 
   gen_chart_fn = fn (chart_type) ->
     def unquote(
@@ -84,7 +83,7 @@ defmodule Chartkick do
     opts
     |> Keyword.take(@options)
     |> Enum.into(%{})
-    |> @json_serializer.encode!()
+    |> Poison.encode!()
   end
 
   defp options_json(opts) when is_bitstring(opts) do

--- a/test/chartkick_test.exs
+++ b/test/chartkick_test.exs
@@ -105,6 +105,18 @@ defmodule ChartkickTest do
     assert String.ends_with?(script, expected)
   end
 
+  test "chartkick_script accepts options as string" do
+    script = Chartkick.chartkick_script("", "", "{}", "{}", false)
+    expected = "</script>"
+    assert String.ends_with?(script, expected)
+  end
+
+  test "chartkick_script accepts options as keyword list" do
+    script = Chartkick.chartkick_script("", "", "{}", [title: "FooBarBaz"], false)
+    expected = "\"title\":\"FooBarBaz\""
+    assert String.contains?(script, expected)
+  end
+
   test "chartkick_script defer adds event listener JS code" do
     script = Chartkick.chartkick_script("LineChart", "", "{}", "{}", true)
     expected = "window.addEventListener(\"load\", createChart, true);"


### PR DESCRIPTION
Hello,

I'm trying to use ChartkickEx (very helpful small library!) but in my current setup. It doesn't work correctly because I'm using turbolinks. I thought about 2 options:

  - add turbolinks:load listener 
  - implement defer by myself with turbolinks listener.


1. Looks simple but might be too library specific to support for you? I've included it in PR but happy to remove.
2. I found some problems with this one. Options are converted to json very early and it's impossible to access options_json/1 because it's private thus constructing custom defer required not only different "chartkick_defer_create_js" from my side but also whole options_json/1 reimplementation. I've moved the converstion to the latest possible stage, just before putting it in the html. 
