### PR TITLE
Set Jason as the default JSON serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Any feedback, suggestions or comments please open an issue or PR.
 All charts expect a JSON string.
 
 ```elixir
-data = Poison.encode!([[175, 60], [190, 80], [180, 75]])
+data = Jason.encode!([[175, 60], [190, 80], [180, 75]])
 ```
 
 Line chart
@@ -55,7 +55,7 @@ Chartkick.scatter_chart data
 Geo chart
 
 ```elixir
-Chartkick.geo_chart Poison.encode!("[[\"United States\",44],[\"Germany\",23]]")
+Chartkick.geo_chart Jason.encode!("[[\"United States\",44],[\"Germany\",23]]")
 ```
 
 Timeline
@@ -235,11 +235,11 @@ Add the following to your project :deps list:
 {:chartkick, "~>0.3.0"}
 ```
 
-Optionally, you can set different JSON encoder, by default it's Poison.
+Optionally, you can set different JSON encoder, by default it's [Jason](https://hex.pm/packages/jason).
 It's used to encode options passed to Chartkick.
 ```
 # config.exs
-config :chartkick, json_serializer: Jason
+config :chartkick, json_serializer: Poison
 ```
 
 By default when you render a chart it will return both the HTML-element and JS that initializes the chart.

--- a/lib/chartkick.ex
+++ b/lib/chartkick.ex
@@ -2,10 +2,10 @@ defmodule Chartkick do
   require EEx
   Module.put_attribute(
     __MODULE__,
-    :poison,
-    if(Code.ensure_loaded?(Poison), do: Poison, else: nil)
+    :jason,
+    if(Code.ensure_loaded?(Jason), do: Jason, else: nil)
   )
-  @json_serializer Application.get_env(:chartkick, :json_serializer) || @poison
+  @json_serializer Application.get_env(:chartkick, :json_serializer) || @jason
 
   gen_chart_fn = fn (chart_type) ->
     def unquote(

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,9 @@ defmodule Chartkick.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{ :uuid, "~> 1.1" },
-     {:poison, "~> 3.0"}]
+    [
+      {:uuid, "~> 1.1"},
+      {:jason, "~> 1.1"}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,4 @@
-%{"poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"}}
+%{
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
This PR swaps Poison with Jason as the default JSON serializer.

Jason seems to be the new standard JSON serializer and deserializer in the Elixir ecosystem. It's been adopted as the default serializer in Ecto due to better performance.