### PR TITLE
Remove Poison as dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ Chartkick.line_chart "{
 
 ## Installation
 
-Optionally, you can set different JSON encoder, by default it's Poison.
-It's used to encode options passed to Chartkick.
+You need to set JSON encoder in your config file. This encoder
+is used to encode options passed to Chartkick.
 ```
 # config.exs
 config :chartkick, json_serializer: Jason

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Any feedback, suggestions or comments please open an issue or PR.
 All charts expect a JSON string.
 
 ```elixir
-data = Poison.encode!([[175, 60], [190, 80], [180, 75]])
+raw_data = [[175, 60], [190, 80], [180, 75]]
+data = Poison.encode!(raw_data)
+# or if you are using Jason
+data = Jason.encode!(raw_data)
 ```
 
 Line chart
@@ -56,6 +59,8 @@ Geo chart
 
 ```elixir
 Chartkick.geo_chart Poison.encode!("[[\"United States\",44],[\"Germany\",23]]")
+# or if you are using Jason
+Chartkick.geo_chart Jason.encode!("[[\"United States\",44],[\"Germany\",23]]")
 ```
 
 Timeline
@@ -228,25 +233,6 @@ Chartkick.line_chart "{
 ```
 
 ## Installation
-
-Add the following to your project :deps list:
-
-```elixir
-{:chartkick, "~>0.4.0"}
-```
-We use [UUID](https://github.com/zyro/elixir-uuid/) as a dependency, so you need to add it to your `extra_applications`
-```elixir
-  def application do
-    [
-    ...
-      extra_applications: [
-        ....
-        :uuid
-      ]
-    ]
-  end
-
-```
 
 Optionally, you can set different JSON encoder, by default it's Poison.
 It's used to encode options passed to Chartkick.

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,4 +21,4 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,2 @@
+use Mix.Config
+config :chartkick, json_serializer: Poison 

--- a/lib/chartkick.ex
+++ b/lib/chartkick.ex
@@ -100,6 +100,6 @@ defmodule Chartkick do
   end
 
   defp json_serializer do
-    Application.get_env(:chartkick, :json_serializer) || Jason
+    Application.get_env(:chartkick, :json_serializer) || Poison
   end
 end

--- a/lib/chartkick.ex
+++ b/lib/chartkick.ex
@@ -100,6 +100,14 @@ defmodule Chartkick do
   end
 
   defp json_serializer do
-    Application.get_env(:chartkick, :json_serializer) || Poison
+    Application.get_env(:chartkick, :json_serializer) ||
+      raise """
+      We could not find any JSON serializer configured. You can add this
+      configuration on your config file
+
+        config :chartkick, json_serializer: <JsonSerializer>
+
+      Choose your prefered json serializer and add it
+      """
   end
 end

--- a/lib/chartkick.ex
+++ b/lib/chartkick.ex
@@ -1,18 +1,15 @@
 defmodule Chartkick do
   require EEx
-  Module.put_attribute(
-    __MODULE__,
-    :poison,
-    if(Code.ensure_loaded?(Poison), do: Poison, else: nil)
-  )
-  @json_serializer Application.get_env(:chartkick, :json_serializer) || @poison
 
-  gen_chart_fn = fn (chart_type) ->
+  gen_chart_fn = fn chart_type ->
     def unquote(
-      chart_type
-      |> Macro.underscore
-      |> String.to_atom
-    )(data_source, options \\ []) do
+          chart_type
+          |> Macro.underscore()
+          |> String.to_atom()
+        )(
+          data_source,
+          options \\ []
+        ) do
       chartkick_chart(unquote(chart_type), data_source, options)
     end
   end
@@ -23,18 +20,24 @@ defmodule Chartkick do
   )
 
   def chartkick_chart(klass, data_source, options \\ []) do
-    id     = Keyword.get_lazy(options, :id, &UUID.uuid4/0)
+    id = Keyword.get_lazy(options, :id, &UUID.uuid4/0)
     height = Keyword.get(options, :height, "300px")
-    width  = Keyword.get(options, :width, "100%")
-    only   = Keyword.get(options, :only)
-    defer  = Keyword.get(options, :defer, false)
+    width = Keyword.get(options, :width, "100%")
+    only = Keyword.get(options, :only)
+    defer = Keyword.get(options, :defer, false)
+
     case only do
-      :html   -> chartkick_tag(id, height, width)
-      :script -> chartkick_script(klass, id, data_source, options, defer)
-      _       -> """
-                 #{ chartkick_tag(id, height, width) }
-                 #{ chartkick_script(klass, id, data_source, options, defer) }
-                 """
+      :html ->
+        chartkick_tag(id, height, width)
+
+      :script ->
+        chartkick_script(klass, id, data_source, options, defer)
+
+      _ ->
+        """
+        #{chartkick_tag(id, height, width)}
+        #{chartkick_script(klass, id, data_source, options, defer)}
+        """
     end
   end
 
@@ -89,10 +92,14 @@ defmodule Chartkick do
     opts
     |> Keyword.take(@options)
     |> Enum.into(%{})
-    |> @json_serializer.encode!()
+    |> json_serializer().encode!()
   end
 
   defp options_json(opts) when is_bitstring(opts) do
     opts
+  end
+
+  defp json_serializer do
+    Application.get_env(:chartkick, :json_serializer) || Jason
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,6 @@ defmodule Chartkick.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:elixir_uuid, "~> 1.2"}, {:poison, "~> 4.0", only: :test}]
+    [{:elixir_uuid, "~> 1.2"}, {:poison, "~> 3.0", only: :test}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,6 @@ defmodule Chartkick.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:elixir_uuid, "~> 1.2"}]
+    [{:elixir_uuid, "~> 1.2"}, {:poison, "~> 4.0", only: :test}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Chartkick.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [extra_applications: [:logger]]
+    [extra_applications: [:logger, :eex]]
   end
 
   defp description do
@@ -48,6 +48,6 @@ defmodule Chartkick.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:elixir_uuid, "~> 1.2"}, {:poison, "~> 3.0"}]
+    [{:elixir_uuid, "~> 1.2"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,4 @@
 %{
-  "elixir_uuid": {:hex, :elixir_uuid, "1.2.1", "dce506597acb7e6b0daeaff52ff6a9043f5919a4c3315abb4143f0b00378c097", [:mix], [], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
+  "elixir_uuid": {:hex, :elixir_uuid, "1.2.1", "dce506597acb7e6b0daeaff52ff6a9043f5919a4c3315abb4143f0b00378c097", [:mix], [], "hexpm", "f7eba2ea6c3555cea09706492716b0d87397b88946e6380898c2889d68585752"},
+  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm", "ba8836feea4b394bb718a161fc59a288fe0109b5006d6bdf97b6badfcf6f0f25"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{
   "elixir_uuid": {:hex, :elixir_uuid, "1.2.1", "dce506597acb7e6b0daeaff52ff6a9043f5919a4c3315abb4143f0b00378c097", [:mix], [], "hexpm", "f7eba2ea6c3555cea09706492716b0d87397b88946e6380898c2889d68585752"},
-  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm", "ba8836feea4b394bb718a161fc59a288fe0109b5006d6bdf97b6badfcf6f0f25"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
 }


### PR DESCRIPTION
Since we are allowing the user to choose either `Poison` or `Jason` as the decoding library, we can remove `Poison` as a dependency and allow the user to install an encoder of their preference

We also add `eex` into extra applications to remove elixir `1.11` warnings