### PR TITLE
fix: `thousands` wasn't correct with the code shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Chartkick.line_chart data, suffix: "%"
 Set a thousands separator - _Chart.js, Highcharts_
 
 ```elixir
+Chartkick.line_chart data, thousands: ","
+```
+
+Set a decimal separator - _Chart.js, Highcharts_
+
+```elixir
 Chartkick.line_chart data, decimal: ","
 ```
 


### PR DESCRIPTION
When reading README, the example shown to the thousands separator isn't correct. Changed the code to show the correct way of declaring a `thousands` separator and added the option of `decimal` separator (both options work since both are presented on `chartkick.ex` options sigil).