### PR TITLE
Chart Options: `round` and `zeros`

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Set a thousands separator - _Chart.js, Highcharts_
 Chartkick.line_chart data, decimal: ","
 ```
 
+Show insignificant zeros, useful for currency - _Chart.js, Highcharts_
+
+```elixir
+Chartkick.line_chart data, round: 2, zeros: true
+```
+
 Show a message when data is empty
 
 ```elixir

--- a/lib/chartkick.ex
+++ b/lib/chartkick.ex
@@ -87,7 +87,7 @@ defmodule Chartkick do
     ~w(klass id data_source options)a
   )
 
-  @options ~w(colors curve dataset decimal discrete donut download label legend library max messages min points prefix refresh stacked suffix thousands title xtitle xtype ytitle)a
+  @options ~w(colors curve dataset decimal discrete donut download label legend library max messages min points prefix refresh stacked suffix thousands title xtitle xtype ytitle zeros round)a
   defp options_json(opts) when is_list(opts) do
     opts
     |> Keyword.take(@options)

--- a/test/chartkick_test.exs
+++ b/test/chartkick_test.exs
@@ -167,8 +167,8 @@ defmodule ChartkickTest do
   end
 
   test "chartkick_chart with chart options" do
-    script = Chartkick.chartkick_chart("", "{}", stacked: true, min: nil, legend: false)
-    expected  = "{\"stacked\":true,\"min\":null,\"legend\":false}"
+    script = Chartkick.chartkick_chart("", "{}", stacked: true, min: nil, legend: false, round: 2, zeros: true)
+    expected  = "{\"zeros\":true,\"stacked\":true,\"round\":2,\"min\":null,\"legend\":false}"
     assert String.contains?(script, expected)
   end
 


### PR DESCRIPTION
### **What was done**
- Added new options to charting. `round` and `zeros` are useful to show currency values.
- Added testing to new options
- Added documentation of new options on README