### PR TITLE
Remove elixir_uuid as dependency

### DIFF
--- a/lib/chartkick.ex
+++ b/lib/chartkick.ex
@@ -20,7 +20,7 @@ defmodule Chartkick do
   )
 
   def chartkick_chart(klass, data_source, options \\ []) do
-    id = Keyword.get_lazy(options, :id, &UUID.uuid4/0)
+    id = Keyword.get_lazy(options, :id, &generate_id_for_chart/0)
     height = Keyword.get(options, :height, "300px")
     width = Keyword.get(options, :width, "100%")
     only = Keyword.get(options, :only)
@@ -38,6 +38,11 @@ defmodule Chartkick do
         #{chartkick_script(klass, id, data_source, options)}
         """
     end
+  end
+
+  defp generate_id_for_chart do
+    length = 36
+    :crypto.strong_rand_bytes(length) |> Base.url_encode64 |> binary_part(0, length)
   end
 
   EEx.function_from_string(

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,6 @@ defmodule Chartkick.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:elixir_uuid, "~> 1.2"}, {:poison, "~> 5.0", only: :test}]
+    [{:poison, "~> 5.0", only: :test}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,3 @@
 %{
-  "elixir_uuid": {:hex, :elixir_uuid, "1.2.1", "dce506597acb7e6b0daeaff52ff6a9043f5919a4c3315abb4143f0b00378c097", [:mix], [], "hexpm", "f7eba2ea6c3555cea09706492716b0d87397b88946e6380898c2889d68585752"},
   "poison": {:hex, :poison, "5.0.0", "d2b54589ab4157bbb82ec2050757779bfed724463a544b6e20d79855a9e43b24", [:mix], [{:decimal, "~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "11dc6117c501b80c62a7594f941d043982a1bd05a1184280c0d9166eb4d8d3fc"},
 }


### PR DESCRIPTION
`elixir_uuid` was causing trouble in my deploy scenario with the latest elixir 1.7.0. Plus it hasn't been updated in 5 years, so I think it might be a good idea to drop it, if all it's needed for is to generate a random string.